### PR TITLE
Add fade detection skeleton

### DIFF
--- a/aaf_reader/CMakeLists.txt
+++ b/aaf_reader/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     aaf_utils.cpp
     aaf_proper_parser.cpp
     aaf_clip_processor.cpp
+    aaf_fade_detector.cpp
     aaf_audio_properties.cpp
     aaf_essence_extractor.cpp
     media_utils.cpp
@@ -34,6 +35,7 @@ set(HEADERS
     media_utils.h
     csv_export.h
     debug_logger.h
+    aaf_fade_detector.h
 )
 
 # Основная программа AAF Reader

--- a/aaf_reader/aaf_clip_processor.cpp
+++ b/aaf_reader/aaf_clip_processor.cpp
@@ -1,4 +1,5 @@
 #include "aaf_clip_processor.h"
+#include "aaf_fade_detector.h"
 #include "aaf_utils.h"
 #include <AAFTypeDefUIDs.h>
 #include <AAFClassDefUIDs.h>
@@ -6,6 +7,7 @@
 
 AAFClipProcessor::AAFClipProcessor(IAAFHeader* pHeader, DebugLogger& logger)
     : m_pHeader(pHeader), logger(logger), audioProperties(nullptr), essenceExtractor(nullptr) {
+    fadeDetector = std::make_unique<AAFFadeDetector>(logger);
 }
 
 AAFClipProcessor::~AAFClipProcessor() {
@@ -55,6 +57,9 @@ void AAFClipProcessor::processSegmentForClips(IAAFSegment* pSegment,
         // Шаг 3: Обрабатываем SourceClip -> MasterMob цепочку
         AAFAudioClipInfo clipInfo = processSourceClipChain(pSourceClip, trackInfo.editRate, currentPosition);
         if (!clipInfo.mobID.empty()) {
+            if (fadeDetector) {
+                fadeDetector->analyzeSegmentForFade(pSegment, clipInfo);
+            }
             trackInfo.clips.push_back(clipInfo);
         }
         

--- a/aaf_reader/aaf_clip_processor.h
+++ b/aaf_reader/aaf_clip_processor.h
@@ -2,6 +2,8 @@
 
 #include "data_structures.h"
 #include "debug_logger.h"
+#include "aaf_fade_detector.h"
+#include <memory>
 #include <AAF.h>
 
 // Forward declarations
@@ -37,4 +39,5 @@ private:
     // Зависимости на другие модули (не владеющие указатели)
     AAFAudioProperties* audioProperties;
     AAFEssenceExtractor* essenceExtractor;
+    std::unique_ptr<AAFFadeDetector> fadeDetector;
 };

--- a/aaf_reader/aaf_fade_detector.cpp
+++ b/aaf_reader/aaf_fade_detector.cpp
@@ -1,0 +1,133 @@
+#include "aaf_fade_detector.h"
+#include "aaf_utils.h"
+#include <string>
+
+AAFFadeDetector::AAFFadeDetector(DebugLogger& logger) : logger(logger) {}
+
+void AAFFadeDetector::analyzeSegmentForFade(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    if (!segment) return;
+    logger.debug(LogCategory::CLIPS, "Analyzing segment for fades");
+    checkTransitions(segment, clipInfo);
+    checkOperationGroups(segment, clipInfo);
+    checkControlTracks(segment, clipInfo);
+    checkFillerEffects(segment, clipInfo);
+    checkDescriptiveMetadata(segment, clipInfo);
+    checkNestedCompositions(segment, clipInfo);
+    checkDataDefinitions(segment, clipInfo);
+    checkModifierEffects(segment, clipInfo);
+    checkFillerStepping(segment, clipInfo);
+    checkCustomOperations(segment, clipInfo);
+    checkProprietaryMetadata(segment, clipInfo);
+}
+
+void AAFFadeDetector::checkTransitions(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    IAAFTransition* transition = nullptr;
+    if (SUCCEEDED(segment->QueryInterface(IID_IAAFTransition, (void**)&transition))) {
+        aafLength_t length = 0;
+        transition->GetTransitionLength(&length);
+        clipInfo.hasFadeIn = true; // simplistic assumption
+        clipInfo.fadeInLength = length;
+        logger.debug(LogCategory::CLIPS, "Fade detected via IAAFTransition" );
+        transition->Release();
+    }
+}
+
+void AAFFadeDetector::checkOperationGroups(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    IAAFOperationGroup* op = nullptr;
+    if (SUCCEEDED(segment->QueryInterface(IID_IAAFOperationGroup, (void**)&op))) {
+        IAAFOperationDef* opDef = nullptr;
+        if (SUCCEEDED(op->GetOperationDefinition(&opDef))) {
+            aafWChar name[128] = {0};
+            if (SUCCEEDED(opDef->GetName(name, sizeof(name)))) {
+                std::string opName = wideToUtf8(name);
+                if (opName.find("Fade") != std::string::npos) {
+                    clipInfo.hasFadeIn = true;
+                    logger.debug(LogCategory::CLIPS, "Fade detected via OperationGroup: " + opName);
+                }
+            }
+            opDef->Release();
+        }
+        aafUInt32 inputs = 0;
+        if (SUCCEEDED(op->CountSourceSegments(&inputs))) {
+            for (aafUInt32 i = 0; i < inputs; ++i) {
+                IAAFSegment* seg = nullptr;
+                if (SUCCEEDED(op->GetInputSegmentAt(i, &seg))) {
+                    analyzeSegmentForFade(seg, clipInfo);
+                    seg->Release();
+                }
+            }
+        }
+        op->Release();
+    }
+}
+
+void AAFFadeDetector::checkControlTracks(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    // Placeholder: in real implementation analyze Parameter/Control tracks
+    logger.trace(LogCategory::CLIPS, "Checking ControlTracks for fade curves");
+}
+
+void AAFFadeDetector::checkFillerEffects(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking Filler for embedded fade effects");
+}
+
+void AAFFadeDetector::checkDescriptiveMetadata(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking descriptive metadata for fade tags");
+}
+
+void AAFFadeDetector::checkNestedCompositions(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking nested compositions for fades");
+    IAAFSourceClip* src = nullptr;
+    if (SUCCEEDED(segment->QueryInterface(IID_IAAFSourceClip, (void**)&src))) {
+        aafSourceRef_t ref;
+        if (SUCCEEDED(src->GetSourceReference(&ref))) {
+            IAAFMob* mob = nullptr;
+            if (SUCCEEDED(src->GetSourceMob(&mob))) {
+                IAAFSegment* seg = nullptr;
+                if (SUCCEEDED(mob->GetEssenceDescriptor((IAAFEssenceDescriptor**)&seg))) {
+                    analyzeSegmentForFade(seg, clipInfo);
+                    seg->Release();
+                }
+                mob->Release();
+            }
+        }
+        src->Release();
+    }
+}
+
+void AAFFadeDetector::checkDataDefinitions(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking DataDefinitions for SoundLevel or Opacity");
+    IAAFComponent* comp = nullptr;
+    if (SUCCEEDED(segment->QueryInterface(IID_IAAFComponent, (void**)&comp))) {
+        IAAFDataDef* dataDef = nullptr;
+        if (SUCCEEDED(comp->GetDataDef(&dataDef))) {
+            aafUID_t uid;
+            if (SUCCEEDED(dataDef->GetAUID(&uid))) {
+                char buf[64];
+                sprintf(buf, "%08X", uid.Data1);
+                std::string id(buf);
+                if (id.find("soundlevel") != std::string::npos) {
+                    clipInfo.hasFadeIn = true;
+                    logger.debug(LogCategory::CLIPS, "Fade implied by DataDefinition" );
+                }
+            }
+            dataDef->Release();
+        }
+        comp->Release();
+    }
+}
+
+void AAFFadeDetector::checkModifierEffects(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking ModifierEffect for fades");
+}
+
+void AAFFadeDetector::checkFillerStepping(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking stepwise filler fades");
+}
+
+void AAFFadeDetector::checkCustomOperations(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking custom OperationDefs for fades");
+}
+
+void AAFFadeDetector::checkProprietaryMetadata(IAAFSegment* segment, AAFAudioClipInfo& clipInfo) {
+    logger.trace(LogCategory::CLIPS, "Checking proprietary KLV or tagged metadata for fades");
+}

--- a/aaf_reader/aaf_fade_detector.h
+++ b/aaf_reader/aaf_fade_detector.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "data_structures.h"
+#include "debug_logger.h"
+#include <AAF.h>
+
+class AAFFadeDetector {
+public:
+    explicit AAFFadeDetector(DebugLogger& logger);
+
+    // Analyze a segment for fade information and update clipInfo
+    void analyzeSegmentForFade(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+
+private:
+    DebugLogger& logger;
+
+    void checkTransitions(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkOperationGroups(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkControlTracks(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkFillerEffects(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkDescriptiveMetadata(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkNestedCompositions(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkDataDefinitions(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkModifierEffects(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkFillerStepping(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkCustomOperations(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+    void checkProprietaryMetadata(IAAFSegment* segment, AAFAudioClipInfo& clipInfo);
+};


### PR DESCRIPTION
## Summary
- add `AAFFadeDetector` module to log potential fade detection across multiple methods
- integrate fade detector with `AAFClipProcessor`
- update CMakeLists

## Testing
- `cmake --build aaf_reader/build` *(fails: could not create CMAKE_GENERATOR)*

------
https://chatgpt.com/codex/tasks/task_e_6862a97352bc833186681d6e6498162f